### PR TITLE
fix: output format

### DIFF
--- a/src/prompts/planner.md
+++ b/src/prompts/planner.md
@@ -43,7 +43,7 @@ interface Step {
 interface Plan {
   thought: string;
   title: string;
-  steps: Plan[];
+  steps: Step[];
 }
 ```
 


### PR DESCRIPTION
Fixed the type of the steps property in the Plan interface from Plan[] to Step[] to correctly reflect the intended output format.